### PR TITLE
Fixing breakage on empty records

### DIFF
--- a/pystardict.py
+++ b/pystardict.py
@@ -158,6 +158,7 @@ class _StarDictIdx(object):
         """ unpack parsed records """
         for matched_record in matched_records:
             c = matched_record.find(b'\x00') + 1
+            if c == 1: continue #Empty record
             record_tuple = unpack(
                 '!%sc%sL' % (c, idx_offset_format), matched_record)
             word, cords = record_tuple[:c - 1], record_tuple[c:]


### PR DESCRIPTION
The dictionary reader breaks when loading Free On-Line Dictionary of Computing (FOLDOC) (file is dictd_www.dict.org_foldoc.ifo) because a record line was empty.  I have added a small check for empty records and skip them.